### PR TITLE
refactor: :recycle: Improvements to recipes

### DIFF
--- a/files/system/usr/share/cheats/cheats.just
+++ b/files/system/usr/share/cheats/cheats.just
@@ -1,23 +1,15 @@
-# Sets up kernel arguments for fan control & sysrq + local initramfs regeneration + enables fingerprint + installs TLP UI from flatpak
+# Enables fingerprint + installs TLP UI from flatpak
 setup-t480s:
     #!/usr/bin/env bash
-    echo 'Applying kernel arguments'
-    rpm-ostree kargs \
-      --append-if-missing="thinkpad_acpi.fan_control=1" \
-      --append-if-missing="sysrq_always_enabled=1" 
-    echo 'Enabling local initramfs regeneration'
-    rpm-ostree initramfs --enable
-    echo 'Enabling fingerprint services'
+    echo 'Enabling zcfan.service'
     sudo systemctl enable zcfan.service
+    echo 'Enabling fingerprint services'
     sudo systemctl start python3-validity.service
     sudo systemctl start open-fprintd.service
     sudo systemctl enable open-fprintd-resume.service open-fprintd-suspend.service open-fprintd.service python3-validity.service
     sudo authselect enable-feature with-fingerprint
     sudo authselect apply-changes
     sudo authselect current
-    echo 'Installing TLP-UI Flatpak'
-    flatpak install --system flathub --noninteractive --assumeyes com.github.d4nj1.tlpui
-    echo 'Remember to reboot!' 
 
 # Installs Flameshot Flatpak & give screenshot permission
 setup-flameshot:

--- a/recipes/kinoite/dnf.yml
+++ b/recipes/kinoite/dnf.yml
@@ -5,6 +5,8 @@ modules:
       copr:
         - birkch/Koi
     install:
+      install-weak-deps: true
+      allow-erasing: true
       packages:
         - Koi
         - kvantum

--- a/recipes/shared/bling.yml
+++ b/recipes/shared/bling.yml
@@ -4,6 +4,8 @@ modules:
       cleanup: true
       nonfree: negativo17
     install:
+      install-weak-deps: true
+      allow-erasing: true
       packages:
         - gstreamer1-plugin-vaapi
         - libheif

--- a/recipes/shared/default-flatpaks.yml
+++ b/recipes/shared/default-flatpaks.yml
@@ -4,5 +4,6 @@ modules:
       - notify: false
         scope: system
         install:
+        - com.github.d4nj1.tlpui
         - com.github.tchx84.Flatseal
         - io.github.flattool.Warehouse

--- a/recipes/shared/dnf-t480s.yml
+++ b/recipes/shared/dnf-t480s.yml
@@ -6,6 +6,7 @@ modules:
         - abn/throttled
         - sneexy/python-validity
     install:
+      install-weak-deps: true
       allow-erasing: true
       packages:
       - igt-gpu-tools

--- a/recipes/shared/kargs.yml
+++ b/recipes/shared/kargs.yml
@@ -1,0 +1,6 @@
+modules:
+  - type: kargs
+    arch: x86_64
+    kargs:
+      - thinkpad_acpi.fan_control=1
+      - sysrq_always_enabled=1

--- a/recipes/silverblue/dnf.yml
+++ b/recipes/silverblue/dnf.yml
@@ -5,6 +5,8 @@ modules:
       copr:
         - dusansimic/themes
     install:
+      install-weak-deps: true
+      allow-erasing: true
       packages:
         # this module installs various packages, organized under categories below
         # ---


### PR DESCRIPTION
- Deploy the `kargs` module, so that thinkpad fan control & SysRq can be used from the first boot
- Added TLP-UI flatpak as a default flatpak installation